### PR TITLE
Update poetry install command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ COPY poetry.lock /source
 COPY pyproject.toml /source
 RUN pip install -U pip poetry
 RUN poetry config virtualenvs.create false
-RUN poetry install --no-dev 
+RUN poetry install --without dev 
 
 # Copy files into image
 # ---------------------------------------------------------------------- #

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ COPY poetry.lock /source
 COPY pyproject.toml /source
 RUN pip install -U pip poetry
 RUN poetry config virtualenvs.create false
-RUN poetry install --without dev 
+RUN poetry install --no-root 
 
 # Copy files into image
 # ---------------------------------------------------------------------- #


### PR DESCRIPTION
I started getting errors in my build saying that `--no-dev` is not an installation option for poetry. That can be confirmed [here](https://github.com/python-poetry/poetry/blob/main/src/poetry/console/commands/install.py)


<img width="1055" alt="Screenshot 2025-01-08 at 1 46 24 PM" src="https://github.com/user-attachments/assets/4ab93fa6-d891-4272-a14b-5bf53c5f4b57" />


<br/>
<br/>
<br/>

Poetry's latest [release](https://github.com/python-poetry/poetry/releases) is treating warnings as errors, so now builds in this project are failing.

<img width="1316" alt="Screenshot 2025-01-08 at 1 54 51 PM" src="https://github.com/user-attachments/assets/8a2b1136-b363-43fc-915d-d20bd7b10b4c" />
